### PR TITLE
fix: Adjust response order with agrees

### DIFF
--- a/lib/requestPromise.js
+++ b/lib/requestPromise.js
@@ -8,8 +8,8 @@ module.exports = function(agrees) {
     requests.forEach((request, i) => {
       request.on('response', (response) => {
         this.checkResponse(response, agrees[i]).on('result', (result) => {
-          results.push(result);
-          if (results.length === requests.length) {
+          results[i] = result;
+          if (results.filter(Boolean).length === requests.length) {
             return resolve(results);
           }
         });


### PR DESCRIPTION
This fixes order of responses.
Order of requests and the responses does not match when response has delayed.

